### PR TITLE
Bug: census Cambio de formato en nombres de censos complejos

### DIFF
--- a/decide/voting/admin.py
+++ b/decide/voting/admin.py
@@ -93,11 +93,11 @@ def censusName(inclList, exclList):
     exclList.sort()
     name = 'Con: '
     for c in inclList:
-        name = name + c + ','
+        name = name + c + '|'
     name = name[:-1]
     name = name + ' Sin: '
     for c in exclList:
-        name = name + c + ','
+        name = name + c + '|'
     name = name[:-1]
     logging.debug("El censo a usar será: " + name)
     return name


### PR DESCRIPTION
Para facilitar la importación y exportación se ha cambiado la coma en el nombre de los censos complejos por un |